### PR TITLE
Dependencies in lower case so Bower installs them too

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "package.json",
     "gulpfile.js"
   ],
-  "Dependencies": {
+  "dependencies": {
     "normalize.css": "~3.0.2"
   }
 }


### PR DESCRIPTION
Normally installing a component will install its dependencies too, and apparently bower.json is case-sensitive so normalize doesn't get installed.
